### PR TITLE
Fixing platform incompatibility issues with 2020.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,9 @@
 # Laravel Make Integration Changelog
 
 ## [Unreleased]
-### Added
 
-### Changed
+Added Support for the 202
 
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
 ## [2.1.0]
 
 ### Changed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,13 +58,13 @@ intellij {
     type = platformType
     downloadSources = platformDownloadSources.toBoolean()
     updateSinceUntilBuild = true
-    alternativeIdePath = "/Users/niclasvaneyk/Library/Application Support/JetBrains/Toolbox/apps/PhpStorm/ch-0/201.8743.18/PhpStorm.app/Contents"
+    alternativeIdePath = "/Users/niclasvaneyk/Library/Application Support/JetBrains/Toolbox/apps/PhpStorm/ch-0/202.6397.115/PhpStorm.app/Contents"
 
 //  Plugin Dependencies:
 //  https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_dependencies.html
 
   setPlugins(
-      "com.jetbrains.php:201.6668.60"
+      "com.jetbrains.php:202.6397.115"
   )
 }
 
@@ -101,7 +101,7 @@ tasks {
     patchPluginXml {
         version(pluginVersion)
         sinceBuild(pluginSinceBuild)
-        untilBuild(pluginUntilBuild)
+        untilBuild(null)
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
         pluginDescription(closure {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@
 
 pluginGroup = com.niclas-van-eyk.laravel-make-integration
 pluginName = Laravel Make Integration
-pluginVersion = 2.1.0
+pluginVersion = 2.1.1
 pluginSinceBuild = 201
-pluginUntilBuild = 201.*
+# pluginUntilBuild = ''
 
 platformType = IU
-platformVersion = 2020.1
+platformVersion = 2020.2
 platformDownloadSources = true


### PR DESCRIPTION
Because during the build process the `build-until` value is set to 201, the plugin does not work with the build of 2020.2.

Now the `build-until` restriction is jut removed, as I do not want to manually increase it every time that a new platform update is released. Most of the time it should just work anyway.