### PR TITLE
Add Popup Action for LaravelMakeActionGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,15 @@
 # Laravel Make Integration Changelog
 
 ## [Unreleased]
+
 ### Added
 
-### Changed
-
-### Deprecated
-
-### Removed
+- A new action to open the <kbd>File</kbd> > <kbd>New</kbd> > <kbd>Laravel</kbd> popup. Take a look at [the PR](https://github.com/NiclasvanEyk/jetbrains-laravel-make-integration/pull/8) for screenshots and more information.
 
 ### Fixed
 
-### Security
+- If you had no interpreter set, the generation would just throw an exception and fail. Now we show a little notification that prompts you to set up a PHP interpreter in Settings > Languages & Frameworks > PHP.
+
 ## [2.1.2]
 
 ### Fixed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,7 @@ intellij {
     type = platformType
     downloadSources = platformDownloadSources.toBoolean()
     updateSinceUntilBuild = true
-    alternativeIdePath = "/Users/niclasvaneyk/Library/Application Support/JetBrains/Toolbox/apps/PhpStorm/ch-0/202.6397.115/PhpStorm.app/Contents"
+    alternativeIdePath = "/Users/niclasvaneyk/Library/Application Support/JetBrains/Toolbox/apps/PhpStorm/ch-0/202.6948.87/PhpStorm.app/Contents"
 
 //  Plugin Dependencies:
 //  https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_dependencies.html

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = com.niclas-van-eyk.laravel-make-integration
 pluginName = Laravel Make Integration
-pluginVersion = 2.1.2
+pluginVersion = 2.2.0
 pluginSinceBuild = 201
 # pluginUntilBuild = ''
 

--- a/src/main/kotlin/com/niclas_van_eyk/laravel_make_integration/actions/ArtisanMakeSubCommandAction.kt
+++ b/src/main/kotlin/com/niclas_van_eyk/laravel_make_integration/actions/ArtisanMakeSubCommandAction.kt
@@ -16,7 +16,7 @@ import com.niclas_van_eyk.laravel_make_integration.targetFileFromEvent
  * This mainly validates the prerequisites for executing artisan.
  */
 abstract class ArtisanMakeSubCommandAction(
-        private val command: SubCommand,
+        val command: SubCommand,
         isFromContextMenu: Boolean = false
 ): DumbAwareAction(LaravelIcons.LaravelLogo) {
     var isFromContextMenu: Boolean = false

--- a/src/main/kotlin/com/niclas_van_eyk/laravel_make_integration/actions/make/RunArtisanMakeDialogAction.kt
+++ b/src/main/kotlin/com/niclas_van_eyk/laravel_make_integration/actions/make/RunArtisanMakeDialogAction.kt
@@ -22,7 +22,7 @@ class RunArtisanMakeDialogAction: DumbAwareAction(LaravelIcons.LaravelLogo) {
         JBPopupFactory
                 .getInstance()
                 .createActionGroupPopup(
-                        "Choose",
+                        "artisan make",
                         ArtisanMakeActionsGroup(
                                 false,
                                 DescriptionMode.Compact

--- a/src/main/kotlin/com/niclas_van_eyk/laravel_make_integration/actions/make/RunArtisanMakeDialogAction.kt
+++ b/src/main/kotlin/com/niclas_van_eyk/laravel_make_integration/actions/make/RunArtisanMakeDialogAction.kt
@@ -1,0 +1,38 @@
+package com.niclas_van_eyk.laravel_make_integration.actions.make
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.niclas_van_eyk.laravel_make_integration.LaravelIcons
+import com.niclas_van_eyk.laravel_make_integration.groups.ArtisanMakeActionsGroup
+import com.niclas_van_eyk.laravel_make_integration.groups.DescriptionMode
+
+/**
+ * Action for opening a modal from which the sub-actions can be run.
+ */
+class RunArtisanMakeDialogAction: DumbAwareAction(LaravelIcons.LaravelLogo) {
+    init {
+        templatePresentation.description = "Run artisan:make"
+        templatePresentation.text        = "Run artisan:make"
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+
+        JBPopupFactory
+                .getInstance()
+                .createActionGroupPopup(
+                        "Choose",
+                        ArtisanMakeActionsGroup(
+                                false,
+                                DescriptionMode.Compact
+                        ),
+                        e.dataContext,
+                        JBPopupFactory.ActionSelectionAid.SPEEDSEARCH,
+                        false,
+                        Runnable {  },
+                        10
+                )
+                .showCenteredInCurrentWindow(project)
+    }
+}

--- a/src/main/kotlin/com/niclas_van_eyk/laravel_make_integration/groups/ArtisanMakeActionsGroup.kt
+++ b/src/main/kotlin/com/niclas_van_eyk/laravel_make_integration/groups/ArtisanMakeActionsGroup.kt
@@ -6,15 +6,34 @@ import com.niclas_van_eyk.laravel_make_integration.actions.ArtisanMakeSubCommand
 import com.niclas_van_eyk.laravel_make_integration.actions.make.*
 import com.niclas_van_eyk.laravel_make_integration.services.LaravelMakeIntegrationProjectService
 
+enum class DescriptionMode {
+    /**
+     * The description of the actions in this group is set to the actual description
+     * of the action.
+     */
+    Normal,
+
+    /**
+     * The description is set to the label of the action.
+     *
+     * This makes sense, if you want to use the JBPopupFactory to display
+     * the group, but only want to show the label and not the full description.
+     */
+    Compact,
+}
+
 /**
  * This is the group of Actions for the File > New menu.
  *
  * This filters the Actions based on the right-clicked folder.
  * @see ArtisanMakeSubCommandAction.isFromContextMenu
  */
-class ArtisanMakeActionsGroup: NonEmptyActionGroup() {
-    private fun computeActions(): Array<ArtisanMakeSubCommandAction> {
-        val actions = arrayOf(
+class ArtisanMakeActionsGroup(
+        private val filterBasedOnSelection: Boolean = true,
+        private val descriptionMode: DescriptionMode = DescriptionMode.Normal
+): NonEmptyActionGroup() {
+    companion object {
+        val AVAILABLE_ACTIONS = arrayOf(
             MakeCastAction(),
             MakeChannelAction(),
             MakeCommandAction(),
@@ -38,10 +57,20 @@ class ArtisanMakeActionsGroup: NonEmptyActionGroup() {
             MakeRuleAction(),
             MakeSeederAction()
         )
+    }
+
+    private fun computeActions(): Array<ArtisanMakeSubCommandAction> {
+        val actions = AVAILABLE_ACTIONS
 
         // These are the actions for the New context menu, so we will filter
         // the actions based on the folder that gets right clicked
-        actions.forEach { it.isFromContextMenu = true }
+        actions.forEach {
+            it.isFromContextMenu = filterBasedOnSelection
+
+            if (descriptionMode === DescriptionMode.Compact) {
+                it.templatePresentation.text = it.command.capitalized
+            }
+        }
 
         return actions
     }

--- a/src/main/kotlin/com/niclas_van_eyk/laravel_make_integration/run/PHPScriptRun.kt
+++ b/src/main/kotlin/com/niclas_van_eyk/laravel_make_integration/run/PHPScriptRun.kt
@@ -111,7 +111,7 @@ class PHPScriptRun(
     private fun inferLocalInterpreter(): PhpInterpreter? {
         return PhpInterpretersManagerImpl.getInstance(project)
             .interpreters
-            .first { !it.isRemote }
+            .firstOrNull { !it.isRemote }
     }
 }
 

--- a/src/main/kotlin/com/niclas_van_eyk/laravel_make_integration/run/ScriptRunFailedException.kt
+++ b/src/main/kotlin/com/niclas_van_eyk/laravel_make_integration/run/ScriptRunFailedException.kt
@@ -1,6 +1,0 @@
-package com.niclas_van_eyk.laravel_make_integration.run
-
-class ScriptRunFailedException(val run: PHPScriptRunListener): Exception() {
-    val output: String
-        get() = run.texts.joinToString("\n")
-}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -28,6 +28,8 @@
             <add-to-group group-id="NewGroup" anchor="after" relative-to-action="NewDir" />
         </group>
 
+        <action class="com.niclas_van_eyk.laravel_make_integration.actions.make.RunArtisanMakeDialogAction" id="ArtisanMakeDialogAction"/>
+
         <!-- We add the list of available Actions here, so they are available through the double shift menu
              and do not get filtered, when you hover over a specific folder -->
         <action class="com.niclas_van_eyk.laravel_make_integration.actions.make.MakeCastAction" id="MakeCastAction"/>


### PR DESCRIPTION
This PR adds an action, that directly triggers the <kbd>File</kbd> > <kbd>New</kbd> > <kbd>Laravel</kbd> popup.

<img width="831" alt="Screenshot 2020-09-05 at 11 32 55" src="https://user-images.githubusercontent.com/10284694/92302321-9cd58700-ef6b-11ea-8fca-359d3ea1818b.png">
<span><img width="147" alt="Screenshot 2020-09-05 at 11 33 46" src="https://user-images.githubusercontent.com/10284694/92302325-ac54d000-ef6b-11ea-9600-4f77e1ada423.png"></span>
<span><img width="154" alt="Screenshot 2020-09-05 at 11 34 04" src="https://user-images.githubusercontent.com/10284694/92302333-b5de3800-ef6b-11ea-8e58-c61a2019b126.png"></span>
<span><img width="398" alt="Screenshot 2020-09-05 at 11 34 21" src="https://user-images.githubusercontent.com/10284694/92302338-becf0980-ef6b-11ea-9735-d71bff409967.png"></span>

This way you can assign it a shortcut and the overview with the different make-subcommands opens, you can type to filter, say `"Contr"` to only show the `Controller` option, and the hit enter to create new Laravel classes even faster!