### PR TITLE
💡 Controller Action Inlay Hints

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,6 +87,7 @@ tasks {
         }
         withType<KotlinCompile> {
             kotlinOptions.jvmTarget = it
+            kotlinOptions.freeCompilerArgs = listOf("-Xjvm-default=compatibility")
         }
     }
 

--- a/src/main/kotlin/com/github/niclasvaneyk/laravelmake/plugin/laravel/routes/codeVision/RouteInlayHintsProvider.kt
+++ b/src/main/kotlin/com/github/niclasvaneyk/laravelmake/plugin/laravel/routes/codeVision/RouteInlayHintsProvider.kt
@@ -1,0 +1,84 @@
+@file:Suppress("UnstableApiUsage")
+
+package com.github.niclasvaneyk.laravelmake.plugin.laravel.routes.codeVision
+
+import com.github.niclasvaneyk.laravelmake.plugin.laravel.laravel
+import com.github.niclasvaneyk.laravelmake.plugin.laravel.routes.codeVision.RouteInlayHintsSettingsSnippetCollector.Companion.isSettingsSnippetEditor
+import com.github.niclasvaneyk.laravelmake.plugin.laravel.routes.introspection.ControllerRoute
+import com.intellij.codeInsight.hints.*
+import com.intellij.codeInsight.hints.presentation.InlayPresentation
+import com.intellij.codeInsight.hints.presentation.PresentationFactory
+import com.intellij.openapi.editor.BlockInlayPriority
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.impl.EditorImpl
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.refactoring.suggested.startOffset
+import com.jetbrains.php.lang.psi.elements.Method
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+/**
+ * See [description] for a description of what this class does.
+ */
+class RouteInlayHintsProvider : InlayHintsProvider<NoSettings> {
+    companion object {
+        internal val KEY: SettingsKey<NoSettings> = SettingsKey("laravel-make.inlay-hints.controller-actions")
+    }
+
+    override val key = KEY
+    override val name = "Laravel controller action methods"
+    override val description = """
+        Shows the HTTP method and path of a controller action above the method mapped to it. Currently only displays one path, if multiple paths point to a single action. 
+    """.trimIndent()
+    override val previewText = RouteInlayHintsSettingsSnippetCollector.SNIPPET
+
+    override fun createSettings() = NoSettings()
+    override fun createConfigurable(settings: NoSettings) = object: ImmediateConfigurable {
+        override fun createComponent(listener: ChangeListener): JComponent = JPanel()
+    }
+
+    override fun getCollectorFor(
+        file: PsiFile,
+        editor: Editor,
+        settings: NoSettings,
+        sink: InlayHintsSink,
+    ): InlayHintsCollector? {
+        if (isSettingsSnippetEditor(editor)) {
+            return RouteInlayHintsSettingsSnippetCollector()
+        }
+        if (editor !is EditorImpl) return null
+        val laravel = file.project.laravel() ?: return null
+        val introspector = laravel.introspection.routeIntrospecter
+        val routes = introspector.snapshot ?: return null
+
+        val routesByMethod = routes
+            .filterIsInstance<ControllerRoute>()
+            .associateBy { it.fqn }
+
+        return ControllerActionInlayHintsCollector(editor, routesByMethod)
+    }
+}
+
+internal class ControllerActionInlayHintsCollector(
+    private val editor: EditorImpl,
+    private val routesByMethod: Map<String, ControllerRoute>,
+    private val factory: PresentationFactory = PresentationFactory(editor),
+) : InlayHintsCollector {
+    override fun collect(element: PsiElement, editor: Editor, sink: InlayHintsSink): Boolean {
+        if (element !is Method) return true
+        val route = routesByMethod[element.fqn] ?: return true
+
+        sink.addCodeVisionElement(editor, element.startOffset, 0, ControllerActionInlayHintPresentation(route, factory).build())
+        return true
+    }
+}
+
+internal class ControllerActionInlayHintPresentation(
+    private val route: ControllerRoute,
+    private val factory: PresentationFactory,
+) {
+    fun build(): InlayPresentation = factory.run {
+        smallTextWithoutBackground("${route.normalizedHttpMethod} ${route.path}")
+    }
+}

--- a/src/main/kotlin/com/github/niclasvaneyk/laravelmake/plugin/laravel/routes/codeVision/RouteInlayHintsSettingsSnippetCollector.kt
+++ b/src/main/kotlin/com/github/niclasvaneyk/laravelmake/plugin/laravel/routes/codeVision/RouteInlayHintsSettingsSnippetCollector.kt
@@ -1,0 +1,57 @@
+@file:Suppress("UnstableApiUsage")
+
+package com.github.niclasvaneyk.laravelmake.plugin.laravel.routes.codeVision
+
+import com.github.niclasvaneyk.laravelmake.plugin.laravel.routes.introspection.BasicRouteInformation
+import com.github.niclasvaneyk.laravelmake.plugin.laravel.routes.introspection.ControllerRoute
+import com.github.niclasvaneyk.laravelmake.plugin.laravel.routes.introspection.RouteOrigin
+import com.intellij.codeInsight.hints.InlayHintsCollector
+import com.intellij.codeInsight.hints.InlayHintsSink
+import com.intellij.codeInsight.hints.addCodeVisionElement
+import com.intellij.codeInsight.hints.presentation.PresentationFactory
+import com.intellij.openapi.editor.BlockInlayPriority
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.impl.EditorImpl
+import com.intellij.psi.PsiElement
+import com.intellij.refactoring.suggested.startOffset
+import com.jetbrains.php.lang.psi.elements.Method
+import com.jetbrains.php.lang.psi.elements.PhpClass
+
+internal class RouteInlayHintsSettingsSnippetCollector() : InlayHintsCollector {
+    companion object {
+        val SNIPPET = """
+            <?php
+            
+            class PostsController 
+            {
+                public function index() 
+                {
+                    // ...
+                }
+            }
+        """.trimIndent()
+
+        fun isSettingsSnippetEditor(editor: Editor): Boolean {
+            return editor.document.text === SNIPPET && editor.isViewer
+        }
+    }
+
+    override fun collect(element: PsiElement, editor: Editor, sink: InlayHintsSink): Boolean {
+        if (element !is Method) return true
+        val route = ControllerRoute(BasicRouteInformation(
+            path = "/posts",
+            httpMethod = "GET",
+            name = "posts.index",
+            middleware = emptyList(),
+        ), RouteOrigin.PROJECT, element.parent as PhpClass, element, null)
+        val factory = PresentationFactory(editor as EditorImpl)
+
+        sink.addCodeVisionElement(
+            editor,
+            element.startOffset,
+            0,
+            ControllerActionInlayHintPresentation(route, factory).build(),
+        )
+        return false
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -31,6 +31,10 @@
     </extensionPoints>
 
     <extensions defaultExtensionNs="com.intellij">
+        <codeInsight.inlayProvider
+            implementationClass="com.github.niclasvaneyk.laravelmake.plugin.laravel.routes.codeVision.RouteInlayHintsProvider"
+            language="PHP"
+        />
         <projectService serviceImplementation="com.github.niclasvaneyk.laravelmake.plugin.jetbrains.settings.LaravelMakeProjectSettings"/>
         <projectConfigurable
             instance="com.github.niclasvaneyk.laravelmake.plugin.jetbrains.settings.LaravelMakeProjectConfigurable"


### PR DESCRIPTION
<img width="481" alt="Screen Shot 2022-04-30 at 14 49 07" src="https://user-images.githubusercontent.com/10284694/166106332-c689b69c-b7cd-4e07-8d77-b3aca57e314a.png">

Makes use of the new experimental Inlay Hints to directly display a mapped path to a controller action above the method. This can also be viewed by hovering over the red icon next to the method, but I personally feel this way it is nicer.

This PR is mostly a proof of concept and still needs refinement. Maybe we should also wait until the API is marked as stable or ship this behind some setting / feature flag.

### Caveats / TODO
- [ ] Inlay hints are not visible, when you open a tab, then scan for routes
- [ ] For some strange reason, the background color of the hint does not really match (as can be seen in the screenshot)